### PR TITLE
Adding a link to the Chadev subreddit in Resources page

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -4,3 +4,4 @@ layout: default
 # Community Resources:
 
 -   ## [The Chadev Calendar](https://www.google.com/calendar/embed?src=4qc3thgj9ocunpfist563utr6g%40group.calendar.google.com&ctz=America/New_York)
+-   ## [The Chadev Subreddit](https://www.reddit.com/r/chadev/)


### PR DESCRIPTION
Not sure why this was left out, but adding a link to the subreddit page as it is still good to let people know about it.  This will be come even more important when the chadev.com domain gets pointed to this site rather than the subreddit.
