### PR TITLE
Fix missing forwardslash in gravatar template.

### DIFF
--- a/_includes/gravatar/image.html
+++ b/_includes/gravatar/image.html
@@ -1,1 +1,1 @@
-{{ 'http://www.gravatar.com/avatar' | append: include.id | append: '.png' | append: '?s=' | append: include.size }}
+{{ 'http://www.gravatar.com/avatar/' | append: include.id | append: '.png' | append: '?s=' | append: include.size }}


### PR DESCRIPTION
Forward slash in gravatar template was missing.
