### PR TITLE
Use relative urls for links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,11 +7,7 @@
 
     <nav class="nav-collapse" role="navigation">
       {% for link in site.links %}
-        {% if link.external %}
         <a href="{{ link.url }}">{{ link.title }}</a>
-        {% else %}
-        <a href="{{ site.url }}{{ link.url }}">{{ link.title }}</a>
-        {% endif %}
       {% endfor %}
     </nav>
 


### PR DESCRIPTION
I'm not sure if there is a reason that we need this.  Since there was an 'if' statement in there I'm wondering if I'm missing something.  However, making this change helps local development quite a bit since you don't get constantly redirected to the main site.
