### PR TITLE
Adding Code of Conduct image for group page and Adding GDG Gigcity to group page

### DIFF
--- a/_data/groups.yml
+++ b/_data/groups.yml
@@ -1,6 +1,6 @@
 -   name: Chadev Lunch
     github: chadev
-    code-of-conduct: 
+    code-of-conduct: http://chadev.github.io/coc/
     gravatar-id: a7b11f2638c847cc186603a646112c21
     urls:
         -   name: website

--- a/assets/images/icons/document.svg
+++ b/assets/images/icons/document.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" width="80.5px" height="77.5px" viewBox="0 0 80.5 77.5" enable-background="new 0 0 80.5 77.5" xml:space="preserve">
+<rect x="23.838" y="31.039" width="31.422" height="3.491"/>
+<rect x="23.838" y="19.741" width="17.457" height="3.491"/>
+<rect x="23.838" y="42.334" width="31.422" height="3.492"/>
+<rect x="23.838" y="53.632" width="31.422" height="3.491"/>
+<path d="M49.911,7.915H15.035v62.056h49.025v-48.58L49.911,7.915z M51.029,14.122l6.516,6.206h-6.516V14.122z M18.758,66.247V11.64  h28.547v12.411h13.031v42.196H18.758z"/>
+</svg>

--- a/groups.html
+++ b/groups.html
@@ -33,10 +33,15 @@ title: Groups
             <a href="{{ url.url }}"><img src="{{ site.url }}/assets/images/icons/twitter-icon.svg" alt=""></a>
 
           {% elsif url.name %}
-            <a href="{{ url.url }}">{{ url.name }}</a>
+          <a href="{{ url.url }}">{{ url.name }}</a>
+
           {% endif %}
 
         {% endfor %}
+
+        {% if page.code-of-conduct %}
+        <a href="{{ page.code-of-conduct }}"><img src="/assets/images/icons/document.svg" alt=""></a>
+        {% endif %}
 
       </div>
 


### PR DESCRIPTION
First of all I know this probably should have been two different PRs, and by probably I mean should definitely have been... my bad...

Adding a image to use for Code of Conduct link on the Groups page, also adding link back to Chadev's CoC to its listing for a unified look (even though it is on the header and on the body of the page).

Also included in this pull request is adding the Google Developer Group to the listing page, with link to its Code of Conduct.  Thank of it as a 2 for one special!  Yes I am very caffeine deprived right now.

I'll work on getting Python, PHP, and Drupal group added in a later PR.
