### PR TITLE
Adjust paddings for events page

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_JOBS: 8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     colorator (0.1)
     execjs (2.2.2)
     fast-stemmer (1.0.2)
+    ffi (1.9.6)
     ffi (1.9.6-x86-mingw32)
     hitimes (1.2.2)
     jekyll (2.5.3)
@@ -61,13 +62,13 @@ GEM
       hitimes
     toml (0.1.2)
       parslet (~> 1.5.0)
-    wdm (0.1.0)
+    yajl-ruby (1.1.0)
     yajl-ruby (1.1.0-x86-mingw32)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES
   jekyll
   sass
-  wdm (~> 0.1.0)

--- a/css/layout/_events.scss
+++ b/css/layout/_events.scss
@@ -1,26 +1,17 @@
 .event {
-  margin-bottom: 1em;
-  
-  h3 {
-    padding-bottom: 0;
-  }
-  
-  > * {
-    padding: .2em 0;
-    line-height: 1.25em;
-  }
-  
+  margin: 2em 0;
+
   .event-details {
     font-size: 0.75em;
   }
-  
+
   .notes {
     font-size: .9em;
   }
-  
+
   address {
-    display: inline-block; 
-    
+    display: inline-block;
+
     &::before {
       content: "|";
     }

--- a/events.html
+++ b/events.html
@@ -1,14 +1,14 @@
 ---
 layout: default
 ---
-        <main id="calendar">
+        <div id="calendar">
             <noscript>
                 Sorry, you need JavaScript to view this page
                 <div class="calendar-container">
                 <iframe src="https://www.google.com/calendar/embed?title=Chadev%20Events&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=4qc3thgj9ocunpfist563utr6g%40group.calendar.google.com&amp;color=%23875509&amp;ctz=America%2FNew_York" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>
                 </div>
             </noscript>
-        </main>
+        </div>
 
         <script type="text/mustache" id="template">
         {% raw %}
@@ -20,7 +20,7 @@ layout: default
                     <div class="event-details">
                         <time class="block">
                             <span class="day"> {{ day }}</span>
-                            <span class="date">{{ month }} {{ date }} </span> 
+                            <span class="date">{{ month }} {{ date }} </span>
                             <span class="time"> {{ time }}</span>
                         </time>
                         {{#address}}


### PR DESCRIPTION
I've tweaked all of the paddings which you can see here:

![screen shot 2015-01-11 at 8 23 43 pm](https://cloud.githubusercontent.com/assets/1642095/5698012/4fa21fee-99d0-11e4-835e-719c16a4dc65.png)

I left aligned the events list so that they match with the header image.  I also added more white space between the events and adjusted the line heights for the fonts.
