### PR TITLE
Update layout of events page.

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,121 +1,165 @@
-function autolink(text) {
-    if(typeof(text) == 'undefined')
-    {
-      return text;
-    }
-
-    // http://jsfiddle.net/kachibito/hEgvc/1/light/
-    return text.replace(/((http|https|ftp):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g,"<a href='$1'>$1</a>");
+function init() {
+  window.body = document.body;
+  window.cal  = document.getElementById('calendar');
+  window.days = [
+    "Sun",
+    "Mon",
+    "Tue",
+    "Wed",
+    "Thu",
+    "Fri",
+    "Sat"
+  ];
+  window.months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ];
+  window.tmpl = document.getElementById('template').innerHTML;
+  window.cal.innerHTML = '';
+  window.body.classList.add('loading');
+  gapi.client.setApiKey('AIzaSyBjug0eGB3rlZPOKN-C5cebniE8at53-G4');
+  gapi.client.load('calendar', 'v3').then(execute);
 }
 
-function formatTime(date) {
-    var
-    output  =   [];
-    output.push((date.getHours() % 12) || 12);
-    output.push(':');
-    output.push(('0' + date.getMinutes()).slice(-2));
-    output.push(date.getHours() > 11 ? ' p.m.' : ' a.m.');
-    return output.join('');
-}
-function displayEvents(data) {
-    var
-    events  =   [],
-    today   =   Date.now(),
-    items    =   data.result.items,
-    j       =   items.length;
-    while(j--) {
-        var
-        obj     =   {};
-        obj.title   =   items[j].summary.replace('/', '/<wbr>');
-        obj.content =   autolink(items[j].description);
-        obj.start   =   new Date((items[j].start.dateTime) ? items[j].start.dateTime : items[j].start.date);
-        obj.month   =   months[obj.start.getMonth()];
-        obj.date    =   obj.start.getDate();
-        obj.day     =   days[obj.start.getDay()]
-        obj.time    =   formatTime(obj.start);
-        try {
-            obj.address =   items[j].location.replace(', United States', '');
-        } catch(e) {}
-        events.unshift(obj);
-    }
-    var templatedata = {
-        'events':   events
-    };
-
-
-    window.cal.innerHTML   =   window.Mustache.render(window.tmpl, templatedata);
-    window.body.classList.remove('loading');
+function execute() {
+  var start = new Date();
+  start.setTime(start.getTime() - (60 * 60 * 24 * 5));
+  displayEventsFor(start);
 }
 
-function errorHandler(error) {
-    window.console.error(error);
-}
+function displayEventsFor(start, end) {
+  end = end || getEndOfMonth(start);
+  var currentStart = start;
+  var request = gapi.client.calendar.events.list({
+    "calendarId": "4qc3thgj9ocunpfist563utr6g@group.calendar.google.com",
+    "singleEvents": "True",
+    "orderBy": "startTime",
+    "timeMin": start.toISOString(),
+    "timeMax": end.toISOString()
 
-function getEndOfMonth(start) {
-    var
-    end         =   new Date(start.getTime());
+  });
+  request.then(displayEvents);
+
+  function getEndOfMonth(start) {
+    var end = new Date(start.getTime());
     end.setMonth(start.getMonth() + 1);
-    end         =   new Date(end - (24 * 60 * 60 * 1000));
+    end = new Date(end - (24 * 60 * 60 * 1000));
     end.setHours(23);
     end.setMinutes(59);
     end.setSeconds(59);
     end.setMilliseconds(999);
     return end;
+  }
 }
 
-function init() {
-    window.body    =   document.body;
-    window.cal     =   document.getElementById('calendar');
-    window.days    =   [
-        "Sun",
-        "Mon",
-        "Tue",
-        "Wed",
-        "Thu",
-        "Fri",
-        "Sat"
-    ];
-    window.months  =   [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December'
-    ];
-    window.tmpl    =   document.getElementById('template').innerHTML;
+function displayEvents(data) {
+  var events          = [],
+      arrangedEvents  = {},
+      today           = Date.now();
 
-    window.cal.innerHTML   =   '';
-    window.body.classList.add('loading');
-    console.log("init running");
-    gapi.client.setApiKey('AIzaSyCp_IflIV150pu3Quu-XDIaM7tMYlfO4DQ');
-    gapi.client.load('calendar', 'v3').then(execute);
-}
+  data.result.items.forEach(function(item) {
+    var obj        = {};
+    obj.title      = item.summary.replace('/', '/<wbr>');
+    obj.content    = autolink(item.description);
+    obj.start      = startDate(item.start);
+    obj.time       = prettyTime(obj.start);
+    obj.meridian   = meridian(obj.start);
+    console.log(item);
 
-function execute() {
-    var start       =   new Date();
-    start.setTime(start.getTime() - (60 * 60 * 24 * 5));
-    displayEventsFor(start);
-}
-
-function displayEventsFor(start, end) {
-    if(!end) {
-        end     =   getEndOfMonth(start);
+    try {
+      obj.address = item.location.replace(', United States', '');
+    } catch(e) {
+      // Do nothing
     }
-    currentStart    =   start;
-    var request = gapi.client.calendar.events.list({
-        "calendarId": "4qc3thgj9ocunpfist563utr6g@group.calendar.google.com",
-        "singleEvents": "True",
-        "orderBy": "startTime",
-        "timeMin": start.toISOString(),
-        "timeMax": end.toISOString()
 
+    var key = dateKey(obj.start);
+    var date = arrangedEvents[key] || { events: [], prettyDate: '' };
+    date.prettyDate = date.prettyDate || prettyDate(obj.start);
+    date.events.push(obj);
+    arrangedEvents[key] = date;
+  });
+
+  arrangedEvents = convertToArray(arrangedEvents);
+
+  var templatedata = {
+    'dates': arrangedEvents
+  };
+
+  window.cal.innerHTML = window.Mustache.render(window.tmpl, templatedata);
+  window.body.classList.remove('loading');
+
+  return;
+
+  function prettyTime(start) {
+    return hour(start) + ":" + minutes(start);
+
+    function hour(time) {
+      var h = time.getUTCHours();
+      return h > 12 ? h - 12 : h;
+    }
+
+    function minutes(time) {
+      var m = time.getUTCMinutes();
+      return m < 10 ? "0" + m : m;
+    }
+
+  }
+
+  function meridian(time) {
+    return time.getUTCHours() > 12 ? 'PM' : 'AM';
+  }
+
+  function prettyDate(start) {
+    var day   = days[start.getDay()],
+        month = months[start.getMonth()],
+        date  = start.getDate();
+    return day + ", " + month + " " + date;
+  }
+
+  function startDate(start) {
+    var date = start.dateTime ? start.dateTime : start.date;
+    return new Date(date);
+  }
+
+  function dateKey(date) {
+    return date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
+  }
+
+  function autolink(text) {
+    if(typeof(text) == 'undefined') { return text; }
+
+    // http://jsfiddle.net/kachibito/hEgvc/1/light/
+    return text.replace(/((http|https|ftp):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g,"<a href='$1'>$1</a>");
+  }
+
+  function formatTime(date) {
+    var output = [];
+    output.push((date.getHours() % 12) || 12);
+    output.push(':');
+    output.push(('0' + date.getMinutes()).slice(-2));
+    output.push(date.getHours() > 11 ? ' p.m.' : ' a.m.');
+    return output.join('');
+  }
+
+  function convertToArray(obj) {
+    var arr =  Object.keys(obj).map(function(key) {
+      return obj[key];
     });
-    request.then(displayEvents);
+
+    return arr;
+  }
+}
+
+function errorHandler(error) {
+  window.console.error(error);
 }

--- a/css/layout/_events.scss
+++ b/css/layout/_events.scss
@@ -1,19 +1,31 @@
+.date {
+  margin-bottom: 42px;
+}
+
 .event {
-  margin: 2em 0;
+  margin: 18px 0 23px 0;
+
+  time {
+    display: inline-block;
+    font-size: 18px;
+    vertical-align: top;
+
+    .meridian {
+      font-size: 12px;
+      margin-left: -3px;
+      padding-right: 20px;
+    }
+  }
 
   .event-details {
-    font-size: 0.75em;
-  }
-
-  .notes {
-    font-size: .9em;
-  }
-
-  address {
     display: inline-block;
 
-    &::before {
-      content: "|";
+    .notes {
+      font-size: .9em;
+    }
+
+    address {
+      display: inline-block;
     }
   }
 }

--- a/events.html
+++ b/events.html
@@ -1,46 +1,52 @@
 ---
 layout: default
 ---
-        <div id="calendar">
-            <noscript>
-                Sorry, you need JavaScript to view this page
-                <div class="calendar-container">
-                <iframe src="https://www.google.com/calendar/embed?title=Chadev%20Events&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=4qc3thgj9ocunpfist563utr6g%40group.calendar.google.com&amp;color=%23875509&amp;ctz=America%2FNew_York" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>
-                </div>
-            </noscript>
-        </div>
+<div id="calendar">
+  <noscript>
+    Sorry, you need JavaScript to view this page
+    <div class="calendar-container">
+      <iframe src="https://www.google.com/calendar/embed?title=Chadev%20Events&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=4qc3thgj9ocunpfist563utr6g%40group.calendar.google.com&amp;color=%23875509&amp;ctz=America%2FNew_York" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
+  </noscript>
+</div>
 
-        <script type="text/mustache" id="template">
-        {% raw %}
-            {{#events.length}}
-            <div id="events" class="no-bullet vcal">
-                {{#events}}
-                <div class="event">
-                    <h3 class="description">{{{ title }}}</h3>
-                    <div class="event-details">
-                        <time class="block">
-                            <span class="day"> {{ day }}</span>
-                            <span class="date">{{ month }} {{ date }} </span>
-                            <span class="time"> {{ time }}</span>
-                        </time>
-                        {{#address}}
-                        <address class="location">
-                            <a href="http://maps.google.com/?q={{ address }}" title="Get Directions">
-                              {{ address }}
-                            </a>
-                        </address>
-                        {{/address}}
-                    </div>
-                    <div class="notes">{{{ content }}}</div>
+<script type="text/mustache" id="template">
+  {% raw %}
+    {{#dates.length}}
+      {{#dates}}
+        <div class="date">
+          <h2>{{prettyDate}}</h2>
+          <div id="events" class="no-bullet vcal">
+            {{#events}}
+              <div class="event">
+                <time>
+                  {{ time }}
+                  <span class="meridian">
+                    {{ meridian }}
+                  </span>
+                </time>
+                <div class="event-details">
+                  <h3 class="description">{{{ title }}}</h3>
+                  <div class="notes">{{{ content }}}</div>
+                  {{#address}}
+                    <address class="location">
+                      <a href="http://maps.google.com/?q={{ address }}" title="Get Directions">
+                        {{ address }}
+                      </a>
+                    </address>
+                  {{/address}}
                 </div>
-                {{/events}}
-            </div>
-            {{/events.length}}
-            {{^events.length}}
-            <p class="no-events">There are no events for this&nbsp;month.</p>
-            {{/events.length}}
-        {% endraw %}
-        </script>
-        <script src="/assets/js/mustache.js"></script>
-        <script src="/assets/js/events.js"></script>
-        <script src="https://apis.google.com/js/client.js?onload=init"></script>
+              </div>
+            {{/events}}
+          </div>
+        </div>
+      {{/dates}}
+    {{/dates.length}}
+    {{^dates.length}}
+      <p class="no-events">There are no events for this&nbsp;month.</p>
+    {{/dates.length}}
+  {% endraw %}
+</script>
+<script src="/assets/js/mustache.js"></script>
+<script src="/assets/js/events.js"></script>
+<script src="https://apis.google.com/js/client.js?onload=init"></script>


### PR DESCRIPTION
I took a stab at redesigning the events page:

Original:

![screen shot 2015-01-11 at 8 26 52 pm](https://cloud.githubusercontent.com/assets/1642095/5715721/4b4b67c0-9aac-11e4-847e-e6d638e5f5dd.png)

New:

![screen shot 2015-01-12 at 10 40 53 pm](https://cloud.githubusercontent.com/assets/1642095/5715712/29c7aff0-9aac-11e4-8cca-d26e35984e7f.png)

In my opinion the date and time of an event is the most important information on this page.  I've tried to design the page to highlight that.

I've grouped the events by a human readable date which has more prominence on the page.  I've also adjusted each event list so that its bulleted with the time the event is occurring (in chronological order).  This allows the user to take in a whole days worth of events at a time.

Ideally I would like to include an actual description of the event and move the title of the event the link.  However, I've left the descriptions as they are for now since we don't currently supply that information.

Let me know what you think.