### PR TITLE
add google API key instructions to README, fixes #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To replicate our development environment a number of open source tools are requi
 $ gem install bundler
 ~~~
 
-###Have bundler resolve your dependencies.
+###Have bundler resolve your dependencies
 
 ~~~ sh
 $ bundle install
@@ -40,3 +40,15 @@ $ jekyll serve
 ###Open Browser
 
 Navigate to http://localhost:4000/
+
+##Acquiring an API key for the events page
+
+1. Go to the [Google Developers Console](https://console.developers.google.com).
+2. Create a new project.
+3. In the sidebar on the left, expand APIs & auth. Next, click APIs. In the list of APIs, make sure the calendar API is turned on.
+4. In the sidebar on the left, select Credentials.
+5. Click Create new Key and select Browser Key.
+6. Enter `*localhost:4000/*` in the *"Accepts Requests From"* text box and click create.
+7. Copy the new API key and replace the one located in the [event.js file](assets/js/events.js).
+8. It should look something like `gapi.client.setApiKey('YOUR API KEY);`.
+9. Wait a few moments, then navigate to [http://localhost:4000/events/](http://localhost:4000/events/) to make sure it worked.


### PR DESCRIPTION
I'm sure this could be tightened up a bit more, but it's a start :wink: 