### PR TITLE
Add the groups.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ $ bundle install
 $ jekyll serve
 ~~~
 
+If that fails you may need to run the Jekyll server with, assuming that
+`bundle install` from the last step was ran.
+
+~~~ sh
+$ bundle exec jekyll serve
+~~~
+
 ###Open Browser
 
 Navigate to http://localhost:4000/

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ $ bundle install
 $ jekyll serve
 ~~~
 
-If that fails you may need to run the Jekyll server with, assuming that
-`bundle install` from the last step was ran.
+If that fails you may need to run the Jekyll server with `bundle exec`.
 
 ~~~ sh
 $ bundle exec jekyll serve

--- a/groups.json
+++ b/groups.json
@@ -1,0 +1,24 @@
+---
+layout: json
+---
+{
+        "groups": [
+                {% for page in site.data.groups %}
+                {
+                        "name": "{{ page.name }}",
+                        "github": "{{ page.github }}",
+                        "code-of-conduct": "{{ page.code-of-conduct }}",
+                        "gravatar-id": "{{ page.gravatar-id }}"{% if page.urls %},
+                        "urls": [
+                                {% for url in page.urls %}
+                                {
+                                        "name": "{{ url.name }}",
+                                        "url": "{{ url.url }}"
+                                }{% if forloop.last == false %},{% endif %}
+                                {% endfor %}
+                        ]
+                        {% endif %}
+                }{% if forloop.last == false %},{% endif %}
+                {% endfor %}
+        ]
+}


### PR DESCRIPTION
Adding a fallback method of starting the Jekyll server encase `jekyll serve` fails.

Also included, unknowingly, is a change that adds a groups.json file to the site, generated by parsing `_data/groups.yml`.  This closes #124 and will be useful for Ash and help in closing https://github.com/chadev/Chadev_ircbot/issues/29.

Signed-off-by: Adam Jimerson <vendion@gmail.com>