### PR TITLE
Add wdm to only the windows platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'sass'
-gem 'wdm', '~> 0.1.0' if Gem.win_platform?
+
+platforms :mswin, :mingw do
+  gem 'wdm', '~> 0.1.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     ffi (1.9.6)
     ffi (1.9.6-x86-mingw32)
     hitimes (1.2.2)
+    hitimes (1.2.2-x86-mingw32)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
@@ -62,6 +63,7 @@ GEM
       hitimes
     toml (0.1.2)
       parslet (~> 1.5.0)
+    wdm (0.1.0)
     yajl-ruby (1.1.0)
     yajl-ruby (1.1.0-x86-mingw32)
 
@@ -72,3 +74,4 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   sass
+  wdm (~> 0.1.0)


### PR DESCRIPTION
~~DO NOT MERGE~~

This should fix issues with MS specific gems trying to be installed on alternative platforms.  However I don't have a MS system to test this on.  @StrangeWill can you see if this works on your box?  It it still presents issues then we might have to try something else.