### PR TITLE
Add Meetup URLs to groups that lack them

### DIFF
--- a/_data/groups.yml
+++ b/_data/groups.yml
@@ -21,6 +21,8 @@
     urls:
         -   name: website
             url: http://lambdaloungecha.github.io/
+        -   name: meetup
+            url: http://www.meetup.com/Chattanooga-Lambda-Lounge
 
 -   name: GDG Gigcity
     github: GDG-Gigcity
@@ -29,6 +31,8 @@
     urls:
       -   name: website
           url: http://gdggigcity.com/
+      -   name: meetup
+          url: http://www.meetup.com/GDG-Gigcity
 
 -   name: Chadev Python
     github: chadev

--- a/groups.html
+++ b/groups.html
@@ -32,7 +32,7 @@ title: Groups
           {% elsif url.name == "twitter" %}
             <a href="{{ url.url }}"><img src="{{ site.url }}/assets/images/icons/profile-icons/twitter-icon.svg" alt=""></a>
 
-          {% elsif url.name %}
+          {% elsif url.name != "meetup" %}
           <a href="{{ url.url }}">{{ url.name }}</a>
 
           {% endif %}


### PR DESCRIPTION
Adding Meetup URLs to groups that have a Meetup group, but don't list it in the
groups.yaml file.  This is used by Ash to pull upcoming event and RSVP
information for the group.