### PR TITLE
Add Jobs link to jobs.chadev.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ links:
     url: /events
   - title: Code of Conduct
     url: /coc
+  - title: Jobs
+    url: http://jobs.chadev.com
 
 # Custom collection settings
 collections:


### PR DESCRIPTION
Adds a link in the header and footer to the job board.