### PR TITLE
New slack signup page.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ links:
   - title: Jobs
     url: http://jobs.chadev.com
   - title: Slack
-    url: http://chadev-slackin.herokuapp.com/
+    url: https://chadev.slack.com/signup
 
 # Custom collection settings
 collections:


### PR DESCRIPTION
Slack has a signup page now available at https://chadev.slack.com/signup that we should be able to enable.

Do we want to do this? If so change the settings on Slack, test the Slack end and accept the PR, otherwise reject.