### PR TITLE
Add CONTRIBUTING.md and CONTRIBUTORS.md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish
+to make via issue, email, or any other method with the owners of this repository
+before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions
+with the project.
+
+## Pull Request Process
+
+1. Fork and clone this project locally.
+2. Install the dependencies for local development as listed in the "Instructions
+   for Local Development" section of the _README.md_.
+2. Update the _README.md_ with details of changes to the interface, this
+   includes new environment variables, exposed ports, useful file locations and
+   container parameters.
+4. You may merge the Pull Request in once you have the sign-off of one other
+   developer, or if you do not have permission to do that, you may request the
+   reviewer to merge it for you.
+
+## Code of Conduct
+
+The Code of Conduct that is detailed in _coc.md_, as well as any amendments
+listed here, applies when contributing to the project.
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,16 @@
+Contributors
+============
+
+These people have contributed to chadev.github.io's design and implementation:
+This is the official list of people who can contribute
+(and typically have contributed) code to the
+chadev.github.io repo.
+
+Names should be added to this file only after verifying that
+the individual or the individual's organization has agreed to
+the CC BY-SA 4.0 International found in the
+COPYING file
+
+Please keep the list sorted.
+
+- Adam Jimerson <vendion -at- gmail.com>


### PR DESCRIPTION
Added a CONTRIBUTING.md which lays out guidelines and some helpful
information to help people who are new to contributing to the project.
This also has a slight amendment to the current CoC to help it be
relevant in this context as well, as current wording feels more geared
to events, rather than contributors to an OSS/F(L)OSS project.

Added a CONTRIBUTORS.md file which doubles as an contributor attribution
list, and as a sign-off that they agree to CC BY-SA 4.0 International
license.

Signed-off-by: Adam Jimerson <vendion@gmail.com>