### PR TITLE
remove live page and update nav links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ url: http://chadev.github.io
 # Links to include in header/footer
 links:
   - title: Live
-    url: /live
+    url: https://www.youtube.com/chadevs/live
   - title: Devs
     url: /devs
   - title: Groups

--- a/live.html
+++ b/live.html
@@ -1,9 +1,0 @@
----
-layout: default
----
-
-<h1>Chadev Live Stream</h1>
-
-<div class="videoWrapper">
-    <iframe src="https://www.youtube.com/embed/iz65rMC-3tE" allow="accelerometer; frameborder="0" allowfullscreen></iframe>
-</div>


### PR DESCRIPTION
This update changes the navigation to update Live to link back to youtube's live page, and removes the html template that was previously there. 